### PR TITLE
Added scaling to SpatialUniformCrop.

### DIFF
--- a/SpatialUniformCrop.lua
+++ b/SpatialUniformCrop.lua
@@ -1,7 +1,12 @@
 local SpatialUniformCrop, parent = torch.class("nn.SpatialUniformCrop", "nn.Module")
 
-function SpatialUniformCrop:__init(oheight, owidth)
+function SpatialUniformCrop:__init(oheight, owidth, scale)
    parent.__init(self)
+   self.scale = scale or nil
+   if self.scale ~= nil then
+      assert(torch.type(scale)=='table')
+      self.scaler = nn.SpatialReSampling{owidth=owidth, oheight=oheight}
+   end
    self.oheight = oheight
    self.owidth = owidth or oheight
 end
@@ -12,18 +17,51 @@ function SpatialUniformCrop:updateOutput(input)
    self.output:resize(input:size(1), input:size(2), self.oheight, self.owidth)
    self.coord = self.coord or torch.IntTensor()
    self.coord:resize(input:size(1), 2)
-   
+
+   if self.scale ~= nil then
+      self.scales = self.scales or torch.FloatTensor()
+      self.scales:resize(input:size(1))
+   end
+  
    local iH, iW = input:size(3), input:size(4)
    if self.train ~= false then
-      for i=1,input:size(1) do
-         -- do random crop
-         local h1 = math.ceil(torch.uniform(1e-2, iH-self.oheight))
-         local w1 = math.ceil(torch.uniform(1e-2, iW-self.owidth))
-         local crop = input[i]:narrow(2,h1,self.oheight):narrow(3,w1,self.owidth)
-         self.output[i]:copy(crop)
-         -- save crop coordinates for backward
-         self.coord[{i,1}] = h1
-         self.coord[{i,2}] = w1
+      if self.scale ~= nil then
+         for i=1,input:size(1) do
+            -- do random crop
+            local s = torch.uniform(scale['min'], scale['max'])
+            local soheight = math.ceil(s*self.oheight)
+            local sowidth = math.ceil(s*self.owidth)
+
+            local h = math.ceil(torch.uniform(1e-2, iH-soheight))
+            local w = math.ceil(torch.uniform(1e-2, iW-sowidth))
+           
+            local ch = math.ceil(iH/2 - (iH-soheight)/2 + h)
+            local cw = math.ceil(iW/2 - (iH-sowidth)/2 + w)
+
+            local h1 = ch - math.ceil(soheight/2)
+            local w1 = cw - math.ceil(sowidth/2)
+            if h1 < 1 then h1 = 1 end
+            if w1 < 1 then w1 = 1 end
+
+            local crop = input[i]:narrow(2, h1, soheight):narrow(3, w1, sowidth)
+
+            self.output[i]:copy(self.scaler:forward(crop))
+            -- save crop coordinates and scale for backward
+            self.scales[i] = s
+            self.coord[{i,1}] = h
+            self.coord[{i,2}] = w
+         end
+      else
+         for i=1,input:size(1) do
+            -- do random crop
+            local h1 = math.ceil(torch.uniform(1e-2, iH-self.oheight))
+            local w1 = math.ceil(torch.uniform(1e-2, iW-self.owidth))
+            local crop = input[i]:narrow(2,h1,self.oheight):narrow(3,w1,self.owidth)
+            self.output[i]:copy(crop)
+            -- save crop coordinates for backward
+            self.coord[{i,1}] = h1
+            self.coord[{i,2}] = w1
+         end
       end
    else
       -- use center crop
@@ -38,10 +76,33 @@ end
 
 function SpatialUniformCrop:updateGradInput(input, gradOutput)
    self.gradInput:resizeAs(input):zero()
-   
-   for i=1,input:size(1) do
-      local h1, w1 = self.coord[{i,1}], self.coord[{i,2}]
-      self.gradInput[i]:narrow(2,h1,self.oheight):narrow(3,w1,self.owidth):copy(gradOutput[i])
+   if self.scale ~= nil then
+      local iH, iW = input:size(3), input:size(4)
+      for i=1,input:size(1) do
+         local s = self.scales[i]
+         local soheight = math.ceil(s*self.oheight)
+         local sowidth = math.ceil(s*self.owidth)
+
+         local h, w = self.coord[{i,1}], self.coord[{i,2}]
+        
+         local ch = math.ceil(iH/2 - (iH-soheight)/2 + h)
+         local cw = math.ceil(iW/2 - (iH-sowidth)/2 + w)
+
+         local h1 = ch - math.ceil(soheight/2)
+         local w1 = cw - math.ceil(sowidth/2)
+         if h1 < 1 then h1 = 1 end
+         if w1 < 1 then w1 = 1 end
+
+         local crop = input[i]:narrow(2, h1, soheight):narrow(3, w1, sowidth)
+         local samplerGradInput = self.scaler:updateGradInput(crop, gradOutput[i])
+
+         self.gradInput[i]:narrow(2, h1, soheight):narrow(3, w1, sowidth):copy(samplerGradInput)
+      end
+   else
+      for i=1,input:size(1) do
+         local h1, w1 = self.coord[{i,1}], self.coord[{i,2}]
+         self.gradInput[i]:narrow(2,h1,self.oheight):narrow(3,w1,self.owidth):copy(gradOutput[i])
+      end
    end
    
    return self.gradInput

--- a/test/test.lua
+++ b/test/test.lua
@@ -342,6 +342,18 @@ function dpnntest.SpatialUniformCrop()
       mytester:assert(math.abs(output[i]:mean() - i) < 0.0001, "SpatialUniformCrop output err "..i)
       mytester:assert(math.abs(gradInput[i]:mean() - ((i*4*4)/(10*10))) < 0.0001, "SpatialUniformCrop gradInput err"..i)
    end
+
+   local input = torch.zeros(1, 1, 120, 120)
+   local temp = input[1]:narrow(2, 30, 60):narrow(3, 30, 60)
+   temp:fill(1)
+   local scale = {}
+   scale['min'] = 0.8
+   scale['max'] = 1.2
+
+   local layer = nn.SpatialUniformCrop(100, 100, scale)
+   local o = layer:forward(input)
+   gradInput = layer:backward(input, o)
+   mytester:assert(gradInput:max() ~= nil, "SpatialUniformCrop scaling error.")
 end
 
 function dpnntest.DontCast()


### PR DESCRIPTION
Sampler usage:
require 'nn'
require 'nnx'
require 'dpnn'

torch.setdefaulttensortype("torch.FloatTensor")

input = torch.rand(1, 1, 120, 120)
-- Scaling range
scale = {}
scale['min'] = 0.8
scale['max'] = 1.2

layer = nn.SpatialUniformCrop(100, 100, scale)
output = layer:forward(input)

gradOutput = torch.rand(1, 1, 100, 100)
gradInput = layer:backward(input, gradOutput)
