### PR TITLE
rectangle-shaped spatial glimpse

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ increasing scale around a given location in a given image.
 The input is a pair of Tensors: `{image, location}`
 `location` are `y,x` coordinates of the center of the different scales 
 of patches to be cropped from image `image`. 
-Coordinates are between `(-1,-1)` (top-left) and `(1,1)` (bottom right).
+Coordinates are between `(-1,-1)` (top-left) and `(1,1)` (bottom-right).
 The `output` is a batch of glimpses taken in image at location `(y,x)`.
 
 `size` can be either a scalar which specifies the `width = height` of glimpses, 

--- a/README.md
+++ b/README.md
@@ -521,12 +521,13 @@ module = nn.SpatialGlimpse(size, depth, scale)
 A glimpse is the concatenation of down-scaled cropped images of 
 increasing scale around a given location in a given image.
 The input is a pair of Tensors: `{image, location}`
-`location` are `x,y` coordinates of the center of the different scales 
+`location` are `y,x` coordinates of the center of the different scales 
 of patches to be cropped from image `image`. 
 Coordinates are between `(-1,-1)` (top-left) and `(1,1)` (bottom right).
-The `output` is a batch of glimpses taken in image at location `(x,y)`.
+The `output` is a batch of glimpses taken in image at location `(y,x).
 
-`size` specifies the `width = height` of glimpses.
+`size` can be either a scalar which specifies the `width = height` of glimpses 
+or a table of {height, width} to support a rectangular shape of glimpses.
 `depth` is number of patches to crop per glimpse (one patch per depth).
 `scale` determines the `size(t) = scale * size(t-1)` of successive cropped patches.
 

--- a/README.md
+++ b/README.md
@@ -524,10 +524,10 @@ The input is a pair of Tensors: `{image, location}`
 `location` are `y,x` coordinates of the center of the different scales 
 of patches to be cropped from image `image`. 
 Coordinates are between `(-1,-1)` (top-left) and `(1,1)` (bottom right).
-The `output` is a batch of glimpses taken in image at location `(y,x).
+The `output` is a batch of glimpses taken in image at location `(y,x)`.
 
-`size` can be either a scalar which specifies the `width = height` of glimpses 
-or a table of {height, width} to support a rectangular shape of glimpses.
+`size` can be either a scalar which specifies the `width = height` of glimpses, 
+or a table of `{height, width}` to support a rectangular shape of glimpses.
 `depth` is number of patches to crop per glimpse (one patch per depth).
 `scale` determines the `size(t) = scale * size(t-1)` of successive cropped patches.
 

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ module = nn.SpatialGlimpse(size, depth, scale)
 A glimpse is the concatenation of down-scaled cropped images of 
 increasing scale around a given location in a given image.
 The input is a pair of Tensors: `{image, location}`
-`location` are `y,x` coordinates of the center of the different scales 
+`location` are `(y,x)` coordinates of the center of the different scales 
 of patches to be cropped from image `image`. 
 Coordinates are between `(-1,-1)` (top-left) and `(1,1)` (bottom-right).
 The `output` is a batch of glimpses taken in image at location `(y,x)`.

--- a/SpatialGlimpse.lua
+++ b/SpatialGlimpse.lua
@@ -7,19 +7,21 @@
 -- locations are x,y coordinates of the center of cropped patches. 
 -- Coordinates are between -1,-1 (top-left) and 1,1 (bottom right)
 -- output is a batch of glimpses taken in image at location (x,y)
--- size specifies width = height of glimpses
+-- glimpse size is (width, height), or (width, width) if height is not provided
 -- depth is number of patches to crop per glimpse (one patch per scale)
 -- Each successive patch is scale x size of the previous patch
 ------------------------------------------------------------------------
 local SpatialGlimpse, parent = torch.class("nn.SpatialGlimpse", "nn.Module")
 
-function SpatialGlimpse:__init(size, depth, scale)
+function SpatialGlimpse:__init(width, depth, scale, height)
    require 'nnx'
-   self.size = size -- height == width
+   self.width = width
+   self.height = height or width -- height==width if height is not specified
    self.depth = depth or 3
    self.scale = scale or 2
    
-   assert(torch.type(self.size) == 'number')
+   assert(torch.type(self.width) == 'number')
+   assert(torch.type(self.height) == 'number')
    assert(torch.type(self.depth) == 'number')
    assert(torch.type(self.scale) == 'number')
    parent.__init(self)
@@ -27,7 +29,7 @@ function SpatialGlimpse:__init(size, depth, scale)
    if self.scale == 2 then
       self.module = nn.SpatialAveragePooling(2,2,2,2)
    else
-      self.module = nn.SpatialReSampling{oheight=size,owidth=size}
+      self.module = nn.SpatialReSampling{oheight=self.height,owidth=self.width}
    end
    self.modules = {self.module}
 end
@@ -41,7 +43,7 @@ function SpatialGlimpse:updateOutput(inputTable)
    input, location = self:toBatch(input, 3), self:toBatch(location, 1)
    assert(input:dim() == 4 and location:dim() == 2)
    
-   self.output:resize(input:size(1), self.depth, input:size(2), self.size, self.size)
+   self.output:resize(input:size(1), self.depth, input:size(2), self.height, self.width)
    
    self._crop = self._crop or self.output.new()
    self._pad = self._pad or input.new()
@@ -56,43 +58,48 @@ function SpatialGlimpse:updateOutput(inputTable)
       y, x = (y+1)/2, (x+1)/2
       
       -- for each depth of glimpse : pad, crop, downscale
-      local glimpseSize = self.size
+      local glimpseWidth = self.width
+      local glimpseHeight = self.height
       for depth=1,self.depth do 
          local dst = outputSample[depth]
          if depth > 1 then
-            glimpseSize = glimpseSize*self.scale
+            glimpseWidth = glimpseWidth*self.scale
+            glimpseHeight = glimpseHeight*self.scale
          end
          
          -- add zero padding (glimpse could be partially out of bounds)
-         local padSize = math.floor((glimpseSize-1)/2)
-         self._pad:resize(input:size(2), input:size(3)+padSize*2, input:size(4)+padSize*2):zero()
-         local center = self._pad:narrow(2,padSize+1,input:size(3)):narrow(3,padSize+1,input:size(4))
+         local padWidth = math.floor((glimpseWidth-1)/2)
+         local padHeight = math.floor((glimpseHeight-1)/2)
+         self._pad:resize(input:size(2), input:size(3)+padHeight*2, input:size(4)+padWidth*2):zero()
+         local center = self._pad:narrow(2,padHeight+1,input:size(3)):narrow(3,padWidth+1,input:size(4))
          center:copy(inputSample)
          
          -- crop it
-         local h, w = self._pad:size(2)-glimpseSize, self._pad:size(3)-glimpseSize
+         local h, w = self._pad:size(2)-glimpseHeight, self._pad:size(3)-glimpseWidth
          local y, x = math.min(h,math.max(0,y*h)),  math.min(w,math.max(0,x*w))
          
          if depth == 1 then
-            dst:copy(self._pad:narrow(2,y+1,glimpseSize):narrow(3,x+1,glimpseSize))
+            dst:copy(self._pad:narrow(2,y+1,glimpseHeight):narrow(3,x+1,glimpseWidth))
          else
-            self._crop:resize(input:size(2), glimpseSize, glimpseSize)
-            self._crop:copy(self._pad:narrow(2,y+1,glimpseSize):narrow(3,x+1,glimpseSize))
+            self._crop:resize(input:size(2), glimpseHeight, glimpseWidth)
+            self._crop:copy(self._pad:narrow(2,y+1,glimpseHeight):narrow(3,x+1,glimpseWidth))
          
             if torch.type(self.module) == 'nn.SpatialAveragePooling' then
-               local poolSize = glimpseSize/self.size
-               assert(poolSize % 2 == 0)
-               self.module.kW = poolSize
-               self.module.kH = poolSize
-               self.module.dW = poolSize
-               self.module.dH = poolSize
+               local poolWidth = glimpseWidth/self.width
+               assert(poolWidth % 2 == 0)
+               local poolHeight = glimpseHeight/self.height
+               assert(poolHeight % 2 == 0)
+               self.module.kW = poolWidth
+               self.module.kH = poolHeight
+               self.module.dW = poolWidth
+               self.module.dH = poolHeight
             end
             dst:copy(self.module:updateOutput(self._crop))
          end
       end
    end
    
-   self.output:resize(input:size(1), self.depth*input:size(2), self.size, self.size)
+   self.output:resize(input:size(1), self.depth*input:size(2), self.height, self.width)
    self.output = self:fromBatch(self.output, 1)
    return self.output
 end
@@ -106,7 +113,7 @@ function SpatialGlimpse:updateGradInput(inputTable, gradOutput)
    gradInput:resizeAs(input):zero()
    gradLocation:resizeAs(location):zero() -- no backprop through location
    
-   gradOutput = gradOutput:view(input:size(1), self.depth, input:size(2), self.size, self.size)
+   gradOutput = gradOutput:view(input:size(1), self.depth, input:size(2), self.height, self.width)
    
    for sampleIdx=1,gradOutput:size(1) do
       local gradOutputSample = gradOutput[sampleIdx]
@@ -118,41 +125,46 @@ function SpatialGlimpse:updateGradInput(inputTable, gradOutput)
       y, x = (y+1)/2, (x+1)/2
       
       -- for each depth of glimpse : pad, crop, downscale
-      local glimpseSize = self.size
+      local glimpseWidth = self.width
+      local glimpseHeight = self.height
       for depth=1,self.depth do 
          local src = gradOutputSample[depth]
          if depth > 1 then
-            glimpseSize = glimpseSize*self.scale
+            glimpseWidth = glimpseWidth*self.scale
+            glimpseHeight = glimpseHeight*self.scale
          end
          
          -- add zero padding (glimpse could be partially out of bounds)
-         local padSize = math.floor((glimpseSize-1)/2)
-         self._pad:resize(input:size(2), input:size(3)+padSize*2, input:size(4)+padSize*2):zero()
+         local padWidth = math.floor((glimpseWidth-1)/2)
+         local padHeight = math.floor((glimpseHeight-1)/2)
+         self._pad:resize(input:size(2), input:size(3)+padHeight*2, input:size(4)+padWidth*2):zero()
          
-         local h, w = self._pad:size(2)-glimpseSize, self._pad:size(3)-glimpseSize
+         local h, w = self._pad:size(2)-glimpseHeight, self._pad:size(3)-glimpseWidth
          local y, x = math.min(h,math.max(0,y*h)),  math.min(w,math.max(0,x*w))
-         local pad = self._pad:narrow(2, y+1, glimpseSize):narrow(3, x+1, glimpseSize)
+         local pad = self._pad:narrow(2, y+1, glimpseHeight):narrow(3, x+1, glimpseWidth)
          
          -- upscale glimpse for different depths
          if depth == 1 then
             pad:copy(src)
          else
-            self._crop:resize(input:size(2), glimpseSize, glimpseSize)
+            self._crop:resize(input:size(2), glimpseHeight, glimpseWidth)
             
             if torch.type(self.module) == 'nn.SpatialAveragePooling' then
-               local poolSize = glimpseSize/self.size
-               assert(poolSize % 2 == 0)
-               self.module.kW = poolSize
-               self.module.kH = poolSize
-               self.module.dW = poolSize
-               self.module.dH = poolSize
+               local poolWidth = glimpseWidth/self.width
+               assert(poolWidth % 2 == 0)
+               local poolHeight = glimpseHeight/self.height
+               assert(poolHeight % 2 == 0)
+               self.module.kW = poolWidth
+               self.module.kH = poolHeight
+               self.module.dW = poolWidth
+               self.module.dH = poolHeight
             end
             
             pad:copy(self.module:updateGradInput(self._crop, src))
          end
         
          -- copy into gradInput tensor (excluding padding)
-         gradInputSample:add(self._pad:narrow(2, padSize+1, input:size(3)):narrow(3, padSize+1, input:size(4)))
+         gradInputSample:add(self._pad:narrow(2, padHeight+1, input:size(3)):narrow(3, padWidth+1, input:size(4)))
       end
    end
    

--- a/SpatialGlimpse.lua
+++ b/SpatialGlimpse.lua
@@ -49,11 +49,11 @@ function SpatialGlimpse:updateOutput(inputTable)
    for sampleIdx=1,self.output:size(1) do
       local outputSample = self.output[sampleIdx]
       local inputSample = input[sampleIdx]
-      local xy = location[sampleIdx]
+      local yx = location[sampleIdx]
       -- (-1,-1) top left corner, (1,1) bottom right corner of image
-      local x, y = xy:select(1,1), xy:select(1,2)
+      local y, x = yx:select(1,1), yx:select(1,2)
       -- (0,0), (1,1)
-      x, y = (x+1)/2, (y+1)/2
+      y, x = (y+1)/2, (x+1)/2
       
       -- for each depth of glimpse : pad, crop, downscale
       local glimpseSize = self.size
@@ -71,13 +71,13 @@ function SpatialGlimpse:updateOutput(inputTable)
          
          -- crop it
          local h, w = self._pad:size(2)-glimpseSize, self._pad:size(3)-glimpseSize
-         local x, y = math.min(h,math.max(0,x*h)),  math.min(w,math.max(0,y*w))
+         local y, x = math.min(h,math.max(0,y*h)),  math.min(w,math.max(0,x*w))
          
          if depth == 1 then
-            dst:copy(self._pad:narrow(2,x+1,glimpseSize):narrow(3,y+1,glimpseSize))
+            dst:copy(self._pad:narrow(2,y+1,glimpseSize):narrow(3,x+1,glimpseSize))
          else
             self._crop:resize(input:size(2), glimpseSize, glimpseSize)
-            self._crop:copy(self._pad:narrow(2,x+1,glimpseSize):narrow(3,y+1,glimpseSize))
+            self._crop:copy(self._pad:narrow(2,y+1,glimpseSize):narrow(3,x+1,glimpseSize))
          
             if torch.type(self.module) == 'nn.SpatialAveragePooling' then
                local poolSize = glimpseSize/self.size
@@ -111,11 +111,11 @@ function SpatialGlimpse:updateGradInput(inputTable, gradOutput)
    for sampleIdx=1,gradOutput:size(1) do
       local gradOutputSample = gradOutput[sampleIdx]
       local gradInputSample = gradInput[sampleIdx]
-      local xy = location[sampleIdx] -- height, width
+      local yx = location[sampleIdx] -- height, width
       -- (-1,-1) top left corner, (1,1) bottom right corner of image
-      local x, y = xy:select(1,1), xy:select(1,2)
+      local y, x = yx:select(1,1), yx:select(1,2)
       -- (0,0), (1,1)
-      x, y = (x+1)/2, (y+1)/2
+      y, x = (y+1)/2, (x+1)/2
       
       -- for each depth of glimpse : pad, crop, downscale
       local glimpseSize = self.size
@@ -130,8 +130,8 @@ function SpatialGlimpse:updateGradInput(inputTable, gradOutput)
          self._pad:resize(input:size(2), input:size(3)+padSize*2, input:size(4)+padSize*2):zero()
          
          local h, w = self._pad:size(2)-glimpseSize, self._pad:size(3)-glimpseSize
-         local x, y = math.min(h,math.max(0,x*h)),  math.min(w,math.max(0,y*w))
-         local pad = self._pad:narrow(2, x+1, glimpseSize):narrow(3, y+1, glimpseSize)
+         local y, x = math.min(h,math.max(0,y*h)),  math.min(w,math.max(0,x*w))
+         local pad = self._pad:narrow(2, y+1, glimpseSize):narrow(3, x+1, glimpseSize)
          
          -- upscale glimpse for different depths
          if depth == 1 then

--- a/SpatialGlimpse.lua
+++ b/SpatialGlimpse.lua
@@ -7,7 +7,7 @@
 -- locations are x,y coordinates of the center of cropped patches. 
 -- Coordinates are between -1,-1 (top-left) and 1,1 (bottom right)
 -- output is a batch of glimpses taken in image at location (x,y)
--- glimpse size is {width, height}, or width only if square-shaped
+-- glimpse size is {height, width}, or width only if square-shaped
 -- depth is number of patches to crop per glimpse (one patch per scale)
 -- Each successive patch is scale x size of the previous patch
 ------------------------------------------------------------------------
@@ -16,8 +16,8 @@ local SpatialGlimpse, parent = torch.class("nn.SpatialGlimpse", "nn.Module")
 function SpatialGlimpse:__init(size, depth, scale)
    require 'nnx'
    if torch.type(width)=='table' then
-      self.width = size[1]
-      self.height = size[2]
+      self.height = size[1]
+      self.width = size[2]
    else
       self.width = size
       self.height = size

--- a/SpatialGlimpse.lua
+++ b/SpatialGlimpse.lua
@@ -15,7 +15,7 @@ local SpatialGlimpse, parent = torch.class("nn.SpatialGlimpse", "nn.Module")
 
 function SpatialGlimpse:__init(size, depth, scale)
    require 'nnx'
-   if torch.type(width)=='table' then
+   if torch.type(size)=='table' then
       self.height = size[1]
       self.width = size[2]
    else

--- a/SpatialGlimpse.lua
+++ b/SpatialGlimpse.lua
@@ -7,16 +7,21 @@
 -- locations are x,y coordinates of the center of cropped patches. 
 -- Coordinates are between -1,-1 (top-left) and 1,1 (bottom right)
 -- output is a batch of glimpses taken in image at location (x,y)
--- glimpse size is (width, height), or (width, width) if height is not provided
+-- glimpse size is {width, height}, or width only if square-shaped
 -- depth is number of patches to crop per glimpse (one patch per scale)
 -- Each successive patch is scale x size of the previous patch
 ------------------------------------------------------------------------
 local SpatialGlimpse, parent = torch.class("nn.SpatialGlimpse", "nn.Module")
 
-function SpatialGlimpse:__init(width, depth, scale, height)
+function SpatialGlimpse:__init(size, depth, scale)
    require 'nnx'
-   self.width = width
-   self.height = height or width -- height==width if height is not specified
+   if torch.type(width)=='table' then
+      self.width = size[1]
+      self.height = size[2]
+   else
+      self.width = size
+      self.height = size
+   end
    self.depth = depth or 3
    self.scale = scale or 2
    

--- a/test/test.lua
+++ b/test/test.lua
@@ -1109,9 +1109,9 @@ function dpnntest.SpatialGlimpseRect()
    local y0 = (input:size(3)-glimpseSize[1])/2 + 1
    local x0 = (input:size(4)-glimpseSize[2])/2 + 1
    local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse center 4 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect center 4 output depth=1 err")
    local outputSize = {batchSize, inputSize[1]*3, glimpseSize[1], glimpseSize[2]}
-   mytester:assertTableEq(output:size():totable(), outputSize, 0.000001, "SpatialGlimpse output size err")
+   mytester:assertTableEq(output:size():totable(), outputSize, 0.000001, "SpatialGlimpseRect output size err")
    
    local input2 = torch.Tensor(unpack(inputSize))
    input2:range(1,input2:nElement())
@@ -1119,7 +1119,7 @@ function dpnntest.SpatialGlimpseRect()
    local sg = nn.SpatialGlimpse(glimpseSize)
    local location2 = torch.Tensor(2):fill(0) -- center patch
    local output2 = sg:forward{input2,location2}
-   mytester:assertTensorEq(output2, output[1], 0.00001, "SpatialGlimpse online output depth=1 err")
+   mytester:assertTensorEq(output2, output[1], 0.00001, "SpatialGlimpseRect online output depth=1 err")
    
    local glimpseSize = {5,3}
    local sg = nn.SpatialGlimpse(glimpseSize)
@@ -1129,7 +1129,7 @@ function dpnntest.SpatialGlimpseRect()
    local y0 = math.floor((input:size(3)-glimpseSize[1])/2) + 1
    local x0 = math.floor((input:size(4)-glimpseSize[2])/2) + 1
    local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse center 5 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect center 5 output depth=1 err")
    
    local glimpseSize = {4,3}
    local sg = nn.SpatialGlimpse(glimpseSize)
@@ -1141,7 +1141,7 @@ function dpnntest.SpatialGlimpseRect()
    pad:narrow(3, padSize[1] + 1, inputSize[2]):narrow(4, padSize[2] + 1, inputSize[3]):copy(input)
    local output2 = pad:narrow(3,1,glimpseSize[1]):narrow(4,1,glimpseSize[2])
    --print('top-left', output2, output_:select(2, 1))
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse top-left 4 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect top-left 4 output depth=1 err")
    
    local glimpseSize = {5,4}
    local sg = nn.SpatialGlimpse(glimpseSize)
@@ -1153,7 +1153,7 @@ function dpnntest.SpatialGlimpseRect()
    local x0 = math.floor((glimpseSize[2]-1)/2) + 1
    pad:narrow(3, y0, inputSize[2]):narrow(4, x0, inputSize[3]):copy(input)
    local output2 = pad:narrow(3,1,glimpseSize[1]):narrow(4,1,glimpseSize[2])
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse top-left 5 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect top-left 5 output depth=1 err")
   
    local glimpseSize = {3,4}
    local sg = nn.SpatialGlimpse(glimpseSize)
@@ -1167,7 +1167,7 @@ function dpnntest.SpatialGlimpseRect()
    local dy = math.floor((glimpseSize[1])/2)
    local dx = math.floor((glimpseSize[2])/2)
    local output2 = pad:narrow(3,inputSize[2]-dy+1,glimpseSize[1]):narrow(4,inputSize[3]-dx+1,glimpseSize[2])
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse bottom-right 4 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect bottom-right 4 output depth=1 err")
    
    local glimpseSize = {4,5}
    local sg = nn.SpatialGlimpse(glimpseSize)
@@ -1182,7 +1182,7 @@ function dpnntest.SpatialGlimpseRect()
    local dx = math.floor((glimpseSize[2])/2)
    local output2 = pad:narrow(3,inputSize[2]-dy+1,glimpseSize[1]):narrow(4,inputSize[3]-dx+1,glimpseSize[2])
    --print('bottom-right', output2, output_:select(2, 1))
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse bottom-right 5 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect bottom-right 5 output depth=1 err")
 
    -- test gradients
    local glimpseSize = {4,3}
@@ -1193,11 +1193,11 @@ function dpnntest.SpatialGlimpseRect()
    local y0 = math.floor((input:size(3)-glimpseSize[1])/2) + 1
    local x0 = math.floor((input:size(4)-glimpseSize[2])/2) + 1
    local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse center 4 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect center 4 output depth=1 err")
    local gradInput = sg:backward({input,location}, output)
    local gradInput2 = input:clone():zero()
    gradInput2:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2]):copy(output_:select(2,1))
-   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse backward 4 depth 1 error")
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpseRect backward 4 depth 1 error")
 
    -- test with spatial resampling
    local sg = nn.SpatialGlimpse(glimpseSize, 2)
@@ -1206,13 +1206,13 @@ function dpnntest.SpatialGlimpseRect()
    local output = sg:forward{input,location}
    local output_ = output:view(batchSize, 2, inputSize[1], glimpseSize[1], glimpseSize[2])
    local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse center 4 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect center 4 output depth=1 err")
    local gradOutput = output:clone()
    gradOutput:view(batchSize, 2, 2, glimpseSize[1], glimpseSize[2]):select(2,1):fill(0) -- ignore first scale of glimpse
    local gradInput = sg:backward({input,location}, gradOutput)
    local srs = nn.SpatialReSampling{oheight=glimpseSize[1]*2,owidth=glimpseSize[2]*2}
    local gradInput2 = srs:updateGradInput(gradInput[1], output_:select(2,2))
-   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse backward 4 depth 2 error")
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpseRect backward 4 depth 2 error")
    
    local sg = nn.SpatialGlimpse(glimpseSize, 2)
    sg.module = nn.SpatialReSampling{owidth=glimpseSize[2],oheight=glimpseSize[1]}
@@ -1220,20 +1220,20 @@ function dpnntest.SpatialGlimpseRect()
    local output = sg:forward{input,location}
    local output_ = output:view(batchSize, 2, inputSize[1], glimpseSize[1], glimpseSize[2])
    local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse center 4 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect center 4 output depth=1 err")
    local gradOutput = output:clone()
    local gradInput = sg:backward({input,location}, gradOutput)
    local gradInput2 = input:clone():zero()
    gradInput2:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2]):copy(output_:select(2,1))
    gradInput2:add(srs:updateGradInput(gradInput[1], output_:select(2,2)))
-   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse backward 4 depth 2 full error")
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpseRect backward 4 depth 2 full error")
    
    local sg = nn.SpatialGlimpse(glimpseSize, 2)
    sg.module = nn.SpatialReSampling{owidth=glimpseSize[2],oheight=glimpseSize[1]}
    local output2 = sg:forward{input[1], location[1]}
    local gradInput2 = sg:backward({input[1], location[1]}, gradOutput[1])
-   mytester:assertTensorEq(gradInput[1][1], gradInput2[1], 0.000001, "SpatialGlimpse backward online img err")
-   mytester:assertTensorEq(gradInput[2][1], gradInput2[2], 0.000001, "SpatialGlimpse backward online loc err")
+   mytester:assertTensorEq(gradInput[1][1], gradInput2[1], 0.000001, "SpatialGlimpseRect backward online img err")
+   mytester:assertTensorEq(gradInput[2][1], gradInput2[2], 0.000001, "SpatialGlimpseRect backward online loc err")
    
    -- test with spatial avg pool
    local sg = nn.SpatialGlimpse(glimpseSize, 2)
@@ -1243,32 +1243,32 @@ function dpnntest.SpatialGlimpseRect()
    local y0 = math.floor((input:size(3)-glimpseSize[1])/2) + 1
    local x0 = math.floor((input:size(4)-glimpseSize[2])/2) + 1
    local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse avgpool center 4 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect avgpool center 4 output depth=1 err")
    local gradOutput = output:clone()
    gradOutput:view(batchSize, 2, 2, glimpseSize[1], glimpseSize[2]):select(2,1):fill(0) -- ignore first scale of glimpse
    local gradInput = sg:backward({input,location}, gradOutput)
    local srs = nn.SpatialAveragePooling(2,2,2,2)
    local gradInput2 = srs:updateGradInput(gradInput[1], output_:select(2,2))
-   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse avgpool backward 4 depth 2 error")
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpseRect avgpool backward 4 depth 2 error")
    
    local sg = nn.SpatialGlimpse(glimpseSize, 2)
    local location = torch.Tensor(batchSize, 2):fill(0) -- center patch
    local output = sg:forward{input,location}
    local output_ = output:view(batchSize, 2, inputSize[1], glimpseSize[1], glimpseSize[2])
    local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse avgpool center 4 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect avgpool center 4 output depth=1 err")
    local gradOutput = output:clone()
    local gradInput = sg:backward({input,location}, gradOutput)
    local gradInput2 = input:clone():zero()
    gradInput2:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2]):copy(output_:select(2,1))
    gradInput2:add(srs:updateGradInput(gradInput[1], output_:select(2,2)))
-   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse avgpool backward 4 depth 2 full error")
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpseRect avgpool backward 4 depth 2 full error")
    
    local sg = nn.SpatialGlimpse(glimpseSize, 2)
    local output2 = sg:forward{input[1], location[1]}
    local gradInput2 = sg:backward({input[1], location[1]}, gradOutput[1])
-   mytester:assertTensorEq(gradInput[1][1], gradInput2[1], 0.000001, "SpatialGlimpse avgpool backward online img err")
-   mytester:assertTensorEq(gradInput[2][1], gradInput2[2], 0.000001, "SpatialGlimpse avgpool backward online loc err")
+   mytester:assertTensorEq(gradInput[1][1], gradInput2[1], 0.000001, "SpatialGlimpseRect avgpool backward online img err")
+   mytester:assertTensorEq(gradInput[2][1], gradInput2[2], 0.000001, "SpatialGlimpseRect avgpool backward online loc err")
    
    -- test avg pool with cuda
    if not pcall(function() require "cunn" end) then return end -- needs the cunn package
@@ -1279,32 +1279,32 @@ function dpnntest.SpatialGlimpseRect()
    local output = sg:forward{input,location}
    local output_ = output:view(batchSize, 2, inputSize[1], glimpseSize[1], glimpseSize[2])
    local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse avgpool center 4 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect avgpool center 4 output depth=1 err")
    local gradOutput = output:clone()
    gradOutput:view(batchSize, 2, 2, glimpseSize[1], glimpseSize[2]):select(2,1):fill(0) -- ignore first scale of glimpse
    local gradInput = sg:backward({input,location}, gradOutput)
    local srs = nn.SpatialAveragePooling(2,2,2,2):cuda()
    local gradInput2 = srs:updateGradInput(gradInput[1], output_:select(2,2))
-   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse avgpool backward 4 depth 2 error")
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpseRect avgpool backward 4 depth 2 error")
    
    local sg = nn.SpatialGlimpse(glimpseSize, 2):cuda()
    local location = torch.CudaTensor(batchSize, 2):fill(0) -- center patch
    local output = sg:forward{input,location}
    local output_ = output:view(batchSize, 2, inputSize[1], glimpseSize[1], glimpseSize[2])
    local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
-   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse avgpool center 4 output depth=1 err")
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpseRect avgpool center 4 output depth=1 err")
    local gradOutput = output:clone()
    local gradInput = sg:backward({input,location}, gradOutput)
    local gradInput2 = input:clone():zero()
    gradInput2:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2]):copy(output_:select(2,1))
    gradInput2:add(srs:updateGradInput(gradInput[1], output_:select(2,2)))
-   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse avgpool backward 4 depth 2 full error")
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpseRect avgpool backward 4 depth 2 full error")
    
    local sg = nn.SpatialGlimpse(glimpseSize, 2):cuda()
    local output2 = sg:forward{input[1], location[1]}
    local gradInput2 = sg:backward({input[1], location[1]}, gradOutput[1])
-   mytester:assertTensorEq(gradInput[1][1], gradInput2[1], 0.000001, "SpatialGlimpse avgpool backward online img err")
-   mytester:assertTensorEq(gradInput[2][1], gradInput2[2], 0.000001, "SpatialGlimpse avgpool backward online loc err")
+   mytester:assertTensorEq(gradInput[1][1], gradInput2[1], 0.000001, "SpatialGlimpseRect avgpool backward online img err")
+   mytester:assertTensorEq(gradInput[2][1], gradInput2[2], 0.000001, "SpatialGlimpseRect avgpool backward online loc err")
    
    if false then
       -- benchmark GPU vs CPU

--- a/test/test.lua
+++ b/test/test.lua
@@ -1090,6 +1090,242 @@ function dpnntest.SpatialGlimpse()
    end
 end
 
+-- test rectangle-shaped glimpse sampling
+function dpnntest.SpatialGlimpseRect()
+   if not pcall(function() require "image" end) then return end -- needs the image package
+   local batchSize = 1
+   local inputSize = {2,8,8}
+   
+   local glimpseSize = {4,2} -- {height, width}
+   local input = torch.Tensor(batchSize, unpack(inputSize))
+   input:range(1,input:nElement())
+   input:resize(batchSize, unpack(inputSize))
+   local sg = nn.SpatialGlimpse(glimpseSize)
+   local location = torch.Tensor(batchSize, 2):fill(0) -- center patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 3, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local y0 = (input:size(3)-glimpseSize[1])/2 + 1
+   local x0 = (input:size(4)-glimpseSize[2])/2 + 1
+   local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse center 4 output depth=1 err")
+   local outputSize = {batchSize, inputSize[1]*3, glimpseSize[1], glimpseSize[2]}
+   mytester:assertTableEq(output:size():totable(), outputSize, 0.000001, "SpatialGlimpse output size err")
+   
+   local input2 = torch.Tensor(unpack(inputSize))
+   input2:range(1,input2:nElement())
+   input2:resize(unpack(inputSize))
+   local sg = nn.SpatialGlimpse(glimpseSize)
+   local location2 = torch.Tensor(2):fill(0) -- center patch
+   local output2 = sg:forward{input2,location2}
+   mytester:assertTensorEq(output2, output[1], 0.00001, "SpatialGlimpse online output depth=1 err")
+   
+   local glimpseSize = {5,3}
+   local sg = nn.SpatialGlimpse(glimpseSize)
+   local location = torch.Tensor(batchSize, 2):fill(0) -- center patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 3, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local y0 = math.floor((input:size(3)-glimpseSize[1])/2) + 1
+   local x0 = math.floor((input:size(4)-glimpseSize[2])/2) + 1
+   local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse center 5 output depth=1 err")
+   
+   local glimpseSize = {4,3}
+   local sg = nn.SpatialGlimpse(glimpseSize)
+   local location = torch.Tensor(batchSize, 2):fill(-1) -- top left corner patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 3, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local padSize = {math.floor((glimpseSize[1]-1)/2), math.floor((glimpseSize[2]-1)/2)}
+   local pad = torch.Tensor(batchSize, inputSize[1], inputSize[2]+padSize[1]*2, inputSize[3]+padSize[2]*2):zero()
+   pad:narrow(3, padSize[1] + 1, inputSize[2]):narrow(4, padSize[2] + 1, inputSize[3]):copy(input)
+   local output2 = pad:narrow(3,1,glimpseSize[1]):narrow(4,1,glimpseSize[1])
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse top-left 4 output depth=1 err")
+   
+   local glimpseSize = {5,4}
+   local sg = nn.SpatialGlimpse(glimpseSize)
+   local location = torch.Tensor(batchSize, 2):fill(-1) -- top left corner patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 3, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local pad = torch.Tensor(batchSize, inputSize[1], inputSize[2]+glimpseSize[1], inputSize[3]+glimpseSize[2]):zero()
+   local y0 = math.floor((glimpseSize[1]-1)/2) + 1
+   local x0 = math.floor((glimpseSize[2]-1)/2) + 1
+   pad:narrow(3, y0, inputSize[2]):narrow(4, x0, inputSize[3]):copy(input)
+   local output2 = pad:narrow(3,1,glimpseSize[1]):narrow(4,1,glimpseSize[2])
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse top-left 5 output depth=1 err")
+  
+   local glimpseSize = {3,4}
+   local sg = nn.SpatialGlimpse(glimpseSize)
+   local location = torch.Tensor(batchSize, 2):fill(1) -- bottom-right corner patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 3, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local pad = torch.Tensor(batchSize, inputSize[1], inputSize[2]+glimpseSize[1], inputSize[3]+glimpseSize[2]):zero()
+   local y0 = math.floor((glimpseSize[1]-1)/2) + 1
+   local x0 = math.floor((glimpseSize[2]-1)/2) + 1
+   pad:narrow(3, y0, inputSize[2]):narrow(4, x0, inputSize[3]):copy(input)
+   local output2 = pad:narrow(3,inputSize[2]-1,glimpseSize[1]):narrow(4,inputSize[3]-1,glimpseSize[2])
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse bottom-right 4 output depth=1 err")
+   
+   local glimpseSize = {4,5}
+   local sg = nn.SpatialGlimpse(glimpseSize)
+   local location = torch.Tensor(batchSize, 2):fill(1) -- bottom-right corner patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 3, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local pad = torch.Tensor(batchSize, inputSize[1], inputSize[2]+glimpseSize[1], inputSize[3]+glimpseSize[2]):zero()
+   local y0 = math.floor((glimpseSize[1]-1)/2)
+   local x0 = math.floor((glimpseSize[2]-1)/2)
+   pad:narrow(3, y0, inputSize[2]):narrow(4, x0, inputSize[3]):copy(input)
+   local output2 = pad:narrow(3,inputSize[2]-1,glimpseSize):narrow(4,inputSize[3]-1,glimpseSize)
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse bottom-right 5 output depth=1 err")
+
+   -- test gradients
+   local glimpseSize = {4,3}
+   local sg = nn.SpatialGlimpse(glimpseSize, 1)
+   local location = torch.Tensor(batchSize, 2):fill(0) -- center patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 1, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local y0 = math.floor((input:size(3)-glimpseSize[1])/2) + 1
+   local x0 = math.floor((input:size(4)-glimpseSize[2])/2) + 1
+   local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse center 4 output depth=1 err")
+   local gradInput = sg:backward({input,location}, output)
+   local gradInput2 = input:clone():zero()
+   gradInput2:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2]):copy(output_:select(2,1))
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse backward 4 depth 1 error")
+
+   -- test with spatial resampling
+   local sg = nn.SpatialGlimpse(glimpseSize, 2)
+   sg.module = nn.SpatialReSampling{owidth=glimpseSize[2],oheight=glimpseSize[1]}
+   local location = torch.Tensor(batchSize, 2):fill(0) -- center patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 2, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local output2 = input:narrow(3,y0,glimpseSize):narrow(4,x0,glimpseSize)
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse center 4 output depth=1 err")
+   local gradOutput = output:clone()
+   gradOutput:view(batchSize, 2, 2, glimpseSize[1], glimpseSize[2]):select(2,1):fill(0) -- ignore first scale of glimpse
+   local gradInput = sg:backward({input,location}, gradOutput)
+   local srs = nn.SpatialReSampling{oheight=glimpseSize[1]*2,owidth=glimpseSize[2]*2}
+   local gradInput2 = srs:updateGradInput(gradInput[1], output_:select(2,2))
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse backward 4 depth 2 error")
+   
+   local sg = nn.SpatialGlimpse(glimpseSize, 2)
+   sg.module = nn.SpatialReSampling{owidth=glimpseSize[2],oheight=glimpseSize[1]}
+   local location = torch.Tensor(batchSize, 2):fill(0) -- center patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 2, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse center 4 output depth=1 err")
+   local gradOutput = output:clone()
+   local gradInput = sg:backward({input,location}, gradOutput)
+   local gradInput2 = input:clone():zero()
+   gradInput2:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2]):copy(output_:select(2,1))
+   gradInput2:add(srs:updateGradInput(gradInput[1], output_:select(2,2)))
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse backward 4 depth 2 full error")
+   
+   local sg = nn.SpatialGlimpse(glimpseSize, 2)
+   sg.module = nn.SpatialReSampling{owidth=glimpseSize[2],oheight=glimpseSize[1]}
+   local output2 = sg:forward{input[1], location[1]}
+   local gradInput2 = sg:backward({input[1], location[1]}, gradOutput[1])
+   mytester:assertTensorEq(gradInput[1][1], gradInput2[1], 0.000001, "SpatialGlimpse backward online img err")
+   mytester:assertTensorEq(gradInput[2][1], gradInput2[2], 0.000001, "SpatialGlimpse backward online loc err")
+   
+   -- test with spatial avg pool
+   local sg = nn.SpatialGlimpse(glimpseSize, 2)
+   local location = torch.Tensor(batchSize, 2):fill(0) -- center patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 2, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local y0 = math.floor((input:size(3)-glimpseSize[1])/2) + 1
+   local x0 = math.floor((input:size(4)-glimpseSize[2])/2) + 1
+   local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse avgpool center 4 output depth=1 err")
+   local gradOutput = output:clone()
+   gradOutput:view(batchSize, 2, 2, glimpseSize[1], glimpseSize[2]):select(2,1):fill(0) -- ignore first scale of glimpse
+   local gradInput = sg:backward({input,location}, gradOutput)
+   local srs = nn.SpatialAveragePooling(2,2,2,2)
+   local gradInput2 = srs:updateGradInput(gradInput[1], output_:select(2,2))
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse avgpool backward 4 depth 2 error")
+   
+   local sg = nn.SpatialGlimpse(glimpseSize, 2)
+   local location = torch.Tensor(batchSize, 2):fill(0) -- center patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 2, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse avgpool center 4 output depth=1 err")
+   local gradOutput = output:clone()
+   local gradInput = sg:backward({input,location}, gradOutput)
+   local gradInput2 = input:clone():zero()
+   gradInput2:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2]):copy(output_:select(2,1))
+   gradInput2:add(srs:updateGradInput(gradInput[1], output_:select(2,2)))
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse avgpool backward 4 depth 2 full error")
+   
+   local sg = nn.SpatialGlimpse(glimpseSize, 2)
+   local output2 = sg:forward{input[1], location[1]}
+   local gradInput2 = sg:backward({input[1], location[1]}, gradOutput[1])
+   mytester:assertTensorEq(gradInput[1][1], gradInput2[1], 0.000001, "SpatialGlimpse avgpool backward online img err")
+   mytester:assertTensorEq(gradInput[2][1], gradInput2[2], 0.000001, "SpatialGlimpse avgpool backward online loc err")
+   
+   -- test avg pool with cuda
+   if not pcall(function() require "cunn" end) then return end -- needs the cunn package
+   local input = input:cuda()
+   
+   local sg = nn.SpatialGlimpse(glimpseSize, 2):cuda()
+   local location = torch.CudaTensor(batchSize, 2):fill(0) -- center patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 2, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse avgpool center 4 output depth=1 err")
+   local gradOutput = output:clone()
+   gradOutput:view(batchSize, 2, 2, glimpseSize[1], glimpseSize[2]):select(2,1):fill(0) -- ignore first scale of glimpse
+   local gradInput = sg:backward({input,location}, gradOutput)
+   local srs = nn.SpatialAveragePooling(2,2,2,2):cuda()
+   local gradInput2 = srs:updateGradInput(gradInput[1], output_:select(2,2))
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse avgpool backward 4 depth 2 error")
+   
+   local sg = nn.SpatialGlimpse(glimpseSize, 2):cuda()
+   local location = torch.CudaTensor(batchSize, 2):fill(0) -- center patch
+   local output = sg:forward{input,location}
+   local output_ = output:view(batchSize, 2, inputSize[1], glimpseSize[1], glimpseSize[2])
+   local output2 = input:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2])
+   mytester:assertTensorEq(output2, output_:select(2, 1), 0.00001, "SpatialGlimpse avgpool center 4 output depth=1 err")
+   local gradOutput = output:clone()
+   local gradInput = sg:backward({input,location}, gradOutput)
+   local gradInput2 = input:clone():zero()
+   gradInput2:narrow(3,y0,glimpseSize[1]):narrow(4,x0,glimpseSize[2]):copy(output_:select(2,1))
+   gradInput2:add(srs:updateGradInput(gradInput[1], output_:select(2,2)))
+   mytester:assertTensorEq(gradInput[1], gradInput2, 0.000001, "SpatialGlimpse avgpool backward 4 depth 2 full error")
+   
+   local sg = nn.SpatialGlimpse(glimpseSize, 2):cuda()
+   local output2 = sg:forward{input[1], location[1]}
+   local gradInput2 = sg:backward({input[1], location[1]}, gradOutput[1])
+   mytester:assertTensorEq(gradInput[1][1], gradInput2[1], 0.000001, "SpatialGlimpse avgpool backward online img err")
+   mytester:assertTensorEq(gradInput[2][1], gradInput2[2], 0.000001, "SpatialGlimpse avgpool backward online loc err")
+   
+   if false then
+      -- benchmark GPU vs CPU
+      local location = torch.FloatTensor(32,2):uniform(-1,1)
+      local input = torch.FloatTensor(32,3,224,224):uniform(0,1)
+      local gradOutput = torch.FloatTensor(32,9,32,32):uniform(0,1)
+      local sg = nn.SpatialGlimpse({32,24}, 3, 2):float()
+      sg:forward{input,location}
+      local a = torch.Timer()
+      for i=1,5 do
+         sg:forward{input,location}
+      end
+      local fwdCPUtime = a:time().real
+      
+      sg:cuda()
+      location = location:cuda()
+      input = input:cuda()
+      gradOutput = gradOutput:cuda()
+      sg:forward{input,location}
+      a = torch.Timer()
+      for i=1,5 do
+         sg:forward{input,location}
+      end
+      local fwdGPUtime = a:time().real
+      print(fwdGPUtime, fwdCPUtime, fwdCPUtime/fwdGPUtime)
+      -- 
+   end
+end
+
 function dpnntest.ArgMax()
    local inputSize = 5
    local batchSize = 3


### PR DESCRIPTION
Update SpatialGlimpse module to support rectangle-shaped patch. It's backward compatible, i.e., the size argument of the constructor supports two kinds of input, a single value for the original square shape and a table of {height, width} for the new rectangular shape. 
The unit test is also updated with the additional case, SpatialGlimpseRect, included in test.lua.
