### PR TITLE
Making the build command cross-platform

### DIFF
--- a/rocks/dpnn-scm-1.rockspec
+++ b/rocks/dpnn-scm-1.rockspec
@@ -23,10 +23,7 @@ dependencies = {
 build = {
    type = "command",
    build_command = [[
-cmake -E make_directory build;
-cd build;
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)"; 
-$(MAKE)
+cmake -E make_directory build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUAROCKS_PREFIX)" -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE)
    ]],
    install_command = "cd build && $(MAKE) install"
 }


### PR DESCRIPTION
Also fixing the case where `$(LUAROCKS_PREFIX) != $(LUA_BINDIR)/..`
