### PR TITLE
Supporting single-number input for OneHot

### DIFF
--- a/OneHot.lua
+++ b/OneHot.lua
@@ -11,7 +11,11 @@ end
 function OneHot:updateOutput(input)
    local size
    if type(input) == 'number' then
-      input = torch.LongTensor({input})
+      if self:type() == 'torch.CudaTensor' then
+			input = torch.CudaTensor({input})
+		else
+			input = torch.LongTensor({input})
+		end
       size = {}
    else
       size = input:size():totable()

--- a/OneHot.lua
+++ b/OneHot.lua
@@ -9,12 +9,18 @@ function OneHot:__init(outputSize)
 end
 
 function OneHot:updateOutput(input)
-   local size = input:size():totable()
+   local size
+   if type(input) == 'number' then
+      input = torch.LongTensor({input})
+      size = {}
+   else
+      size = input:size():totable()
+   end
    table.insert(size, self.outputSize)
    
    self.output:resize(unpack(size)):zero()
    
-   size[input:dim()+1] = 1
+   size[#size] = 1
    local input_ = input:view(unpack(size))
    
    if torch.type(input) == 'torch.CudaTensor' or torch.type(input) == 'torch.ClTensor' then
@@ -38,8 +44,12 @@ function OneHot:updateOutput(input)
 end
 
 function OneHot:updateGradInput(input, gradOutput)
-   self.gradInput:resize(input:size()):zero()
-   return self.gradInput
+   if type(input) == 'number' then
+      return 0
+   else
+      self.gradInput:resize(input:size()):zero()
+      return self.gradInput
+   end
 end
 
 function OneHot:type(type, typecache)

--- a/OneHot.lua
+++ b/OneHot.lua
@@ -12,10 +12,12 @@ function OneHot:updateOutput(input)
    local size
    if type(input) == 'number' then
       if self:type() == 'torch.CudaTensor' then
-			input = torch.CudaTensor({input})
-		else
-			input = torch.LongTensor({input})
-		end
+         self._single = self._single or torch.CudaTensor():resize(1);
+      else
+         self._single = self._single or torch.LongTensor():resize(1);
+      end
+      self._single[1] = input
+      input = self._single;
       size = {}
    else
       size = input:size():totable()
@@ -57,6 +59,7 @@ function OneHot:updateGradInput(input, gradOutput)
 end
 
 function OneHot:type(type, typecache)
+   self._single = nil
    self._input = nil
    return parent.type(self, type, typecache)
 end

--- a/test/test.lua
+++ b/test/test.lua
@@ -2085,6 +2085,12 @@ function dpnntest.OneHot()
    mytester:assertTensorEq(output, output2, 0.000001, "OneHot forward batch err")
    mytester:assert(output:dim() == 2)
 
+   -- non-batch mode (number input)
+   local num = 3
+   local output3 = torch.zeros(nClass)
+   output3[num] = 1.0
+   mytester:assertTensorEq(oh:forward(num), output3, 0.000001, "OneHot forward number err")
+
    local gradInput = oh:backward(input, gradOutput)
    mytester:assertTensorEq(gradInput, input:double():zero(), 0.000001, "OneHot backward batch err")
 
@@ -2107,6 +2113,9 @@ function dpnntest.OneHot()
       local gradInput2 = oh:backward(input, gradOutput)
       mytester:assertTensorEq(gradInput, gradInput2:double(), 0.000001, "OneHot backward batch err")
       cutorch.synchronize()
+
+      -- non-batch mode (number input)
+      mytester:assertTensorEq(oh:forward(num), output3:cuda(), 0.000001, "OneHot forward number err")
    end
    
    -- multi-dimensional input


### PR DESCRIPTION
This is useful for debugging or other use-cases that don't require batch mode. Of course, the gradient doesn't make sense for OneHot so gradInput is `0` if the input is a `number`. Including support and tests for CUDA and non-CUDA usage.
