### PR TITLE
Make ArgMax compatible with new cutorch (with CudaLongTensor)

### DIFF
--- a/ArgMax.lua
+++ b/ArgMax.lua
@@ -19,7 +19,7 @@ end
 function ArgMax:updateOutput(input)
    self._value = self._value or input.new()
    self._indices = self._indices or
-      (torch.type(input) == 'torch.CudaTensor' and torch.CudaTensor() or torch.LongTensor())
+      (torch.type(input) == 'torch.CudaTensor' and (torch.CudaLongTensor and torch.CudaLongTensor() or torch.CudaTensor()) or torch.LongTensor())
    local dim = (input:dim() > self.nInputDim) and (self.dim + 1) or self.dim
    
    torch.max(self._value, self._indices, input, dim)


### PR DESCRIPTION
In the new version (master branch) of cutorch, the indices should be in the type torch.CudaLongTensor instead of torch.CudaTensor.
